### PR TITLE
Add CI workflow and extra test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-php@v3
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.3'
       - run: composer install --no-interaction --prefer-dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-php@v3
+        with:
+          php-version: '8.3'
+      - run: composer install --no-interaction --prefer-dist
+      - run: vendor/bin/phpunit --configuration phpunit.xml

--- a/tests/DatePatternGeneratorNegativeTest.php
+++ b/tests/DatePatternGeneratorNegativeTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Html5PatternGenerator\Pattern\DatePatternGenerator;
+use PHPUnit\Framework\TestCase;
+
+class DatePatternGeneratorNegativeTest extends TestCase
+{
+    public function testBetweenThrowsForInvalidRange(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        DatePatternGenerator::between(
+            new DateTimeImmutable('2024-05-10'),
+            new DateTimeImmutable('2024-05-01')
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests
- add negative test for invalid date ranges

## Testing
- `composer install --no-interaction`
- `vendor/bin/phpunit --configuration phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_684b3634ecdc8320811a000e204dae8f