### PR TITLE
Add Playwright browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,3 +14,9 @@ jobs:
           php-version: '8.3'
       - run: composer install --no-interaction --prefer-dist
       - run: vendor/bin/phpunit --configuration phpunit.xml
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npx playwright install --with-deps
+      - run: npm run test:browser

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 composer.lock
 /vendor/
+node_modules/
+test-results/
 /.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -63,3 +63,14 @@ $futurePattern = DatePatternGenerator::after(new DateTimeImmutable('2024-06-01')
 $pastPattern = DatePatternGenerator::before(new DateTimeImmutable('2024-06-01'), 7);
 ```
 
+
+## Running browser tests locally
+
+Browser tests use [Playwright](https://playwright.dev/). Install PHP and Node dependencies, then install the Playwright browsers:
+
+```bash
+composer install
+npm install
+npx playwright install --with-deps
+npm run test:browser
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "html5-pattern-generator",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "html5-pattern-generator",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "^1.53.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.53.0.tgz",
+      "integrity": "sha512-15hjKreZDcp7t6TL/7jkAo6Df5STZN09jGiv5dbP9A6vMVncXRqE7/B2SncsyOwrkZRBH2i6/TPOL8BVmm3c7w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.53.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.0.tgz",
+      "integrity": "sha512-ghGNnIEYZC4E+YtclRn4/p6oYbdPiASELBIYkBXfaTVKreQUYbMUYQDwS12a8F0/HtIjr/CkGjtwABeFPGcS4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.53.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.53.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.0.tgz",
+      "integrity": "sha512-mGLg8m0pm4+mmtB7M89Xw/GSqoNC+twivl8ITteqvAndachozYe2ZA7srU6uleV1vEdAHYqjq+SV8SNxRRFYBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "html5-pattern-generator",
+  "version": "1.0.0",
+  "description": "This library provides utilities to build HTML5 pattern attributes for client-side form validation.",
+  "main": "index.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "npm run test:browser",
+    "test:browser": "playwright test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "@playwright/test": "^1.53.0"
+  }
+}

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,5 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: './tests/browser',
+});

--- a/tests/PatternGeneratorTest.php
+++ b/tests/PatternGeneratorTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Html5PatternGenerator\PatternGenerator;
+use PHPUnit\Framework\TestCase;
+
+class PatternGeneratorTest extends TestCase
+{
+    public function testGenerateMatchesAlphaNumeric(): void
+    {
+        $generator = new PatternGenerator();
+        $regex = '/^' . $generator->generate() . '$/';
+        $this->assertMatchesRegularExpression($regex, 'abc123');
+        $this->assertDoesNotMatchRegularExpression($regex, 'abc-123');
+    }
+}

--- a/tests/browser/datepattern.spec.js
+++ b/tests/browser/datepattern.spec.js
@@ -1,0 +1,96 @@
+const { test, expect } = require('@playwright/test');
+const { execSync } = require('child_process');
+const path = require('path');
+
+const root = path.resolve(__dirname, '../..');
+
+function getPattern(expr) {
+  const cmd = `php -r "require 'vendor/autoload.php'; echo ${expr};"`;
+  let pattern = execSync(cmd, { cwd: root }).toString();
+  pattern = pattern.trim().replace(/\\-/g, '-');
+  return pattern;
+}
+
+test('default pattern validates dates', async ({ page }) => {
+  const pattern = getPattern('Html5PatternGenerator\\\\Pattern\\\\DatePatternGenerator::pattern()');
+
+  await page.setContent('<form><input id="date"></form>');
+  await page.evaluate((p) => {
+    document.getElementById('date').setAttribute('pattern', p);
+  }, pattern);
+
+  const input = page.locator('#date');
+
+  await input.fill('2024-05-01');
+  const valid = await input.evaluate(el => el.checkValidity());
+  expect(valid).toBe(true);
+
+  await input.fill('2024-13-01');
+  const invalid = await input.evaluate(el => el.checkValidity());
+  expect(invalid).toBe(false);
+});
+
+test('custom format d.m.Y validates dates', async ({ page }) => {
+  const pattern = getPattern("Html5PatternGenerator\\\\Pattern\\\\DatePatternGenerator::pattern('d.m.Y')");
+
+  await page.setContent('<form><input id="date"></form>');
+  await page.evaluate((p) => {
+    document.getElementById('date').setAttribute('pattern', p);
+  }, pattern);
+
+  const input = page.locator('#date');
+
+  await input.fill('01.05.2024');
+  const valid = await input.evaluate(el => el.checkValidity());
+  expect(valid).toBe(true);
+
+  await input.fill('2024-05-01');
+  const invalid = await input.evaluate(el => el.checkValidity());
+  expect(invalid).toBe(false);
+});
+
+test('between pattern restricts date range', async ({ page }) => {
+  const pattern = getPattern("Html5PatternGenerator\\\\Pattern\\\\DatePatternGenerator::between(new DateTimeImmutable('2024-05-01'), new DateTimeImmutable('2024-05-03'))");
+
+  await page.setContent('<form><input id="date"></form>');
+  await page.evaluate((p) => {
+    document.getElementById('date').setAttribute('pattern', p);
+  }, pattern);
+
+  const input = page.locator('#date');
+
+  await input.fill('2024-05-02');
+  const valid = await input.evaluate(el => el.checkValidity());
+  expect(valid).toBe(true);
+
+  await input.fill('2024-05-04');
+  const invalid = await input.evaluate(el => el.checkValidity());
+  expect(invalid).toBe(false);
+});
+
+test('after and before patterns', async ({ page }) => {
+  const afterPattern = getPattern("Html5PatternGenerator\\\\Pattern\\\\DatePatternGenerator::after(new DateTimeImmutable('2024-06-01'), 2)");
+  const beforePattern = getPattern("Html5PatternGenerator\\\\Pattern\\\\DatePatternGenerator::before(new DateTimeImmutable('2024-07-10'), 1)");
+
+  await page.setContent('<form><input id="after"><input id="before"></form>');
+  await page.evaluate(({after, before}) => {
+    document.getElementById('after').setAttribute('pattern', after);
+    document.getElementById('before').setAttribute('pattern', before);
+  }, { after: afterPattern, before: beforePattern });
+
+  const afterInput = page.locator('#after');
+  await afterInput.fill('2024-06-03');
+  const afterValid = await afterInput.evaluate(el => el.checkValidity());
+  expect(afterValid).toBe(true);
+  await afterInput.fill('2024-06-04');
+  const afterInvalid = await afterInput.evaluate(el => el.checkValidity());
+  expect(afterInvalid).toBe(false);
+
+  const beforeInput = page.locator('#before');
+  await beforeInput.fill('2024-07-09');
+  const beforeValid = await beforeInput.evaluate(el => el.checkValidity());
+  expect(beforeValid).toBe(true);
+  await beforeInput.fill('2024-07-08');
+  const beforeInvalid = await beforeInput.evaluate(el => el.checkValidity());
+  expect(beforeInvalid).toBe(false);
+});

--- a/tests/browser/datepattern.spec.js
+++ b/tests/browser/datepattern.spec.js
@@ -94,3 +94,57 @@ test('after and before patterns', async ({ page }) => {
   const beforeInvalid = await beforeInput.evaluate(el => el.checkValidity());
   expect(beforeInvalid).toBe(false);
 });
+
+test('custom format Y.m.d validates dates', async ({ page }) => {
+  const pattern = getPattern("Html5PatternGenerator\\\\Pattern\\\\DatePatternGenerator::pattern('Y.m.d')");
+
+  await page.setContent('<form><input id="date"></form>');
+  await page.evaluate((p) => {
+    document.getElementById('date').setAttribute('pattern', p);
+  }, pattern);
+
+  const input = page.locator('#date');
+  await input.fill('2024.05.01');
+  const valid = await input.evaluate(el => el.checkValidity());
+  expect(valid).toBe(true);
+
+  await input.fill('2024-05-01');
+  const invalid = await input.evaluate(el => el.checkValidity());
+  expect(invalid).toBe(false);
+});
+
+test('format with slashes Y/m/d validates dates', async ({ page }) => {
+  const pattern = getPattern("Html5PatternGenerator\\\\Pattern\\\\DatePatternGenerator::pattern('Y/m/d')");
+
+  await page.setContent('<form><input id="date"></form>');
+  await page.evaluate((p) => {
+    document.getElementById('date').setAttribute('pattern', p);
+  }, pattern);
+
+  const input = page.locator('#date');
+  await input.fill('2024/05/01');
+  const valid = await input.evaluate(el => el.checkValidity());
+  expect(valid).toBe(true);
+
+  await input.fill('05/01/2024');
+  const invalid = await input.evaluate(el => el.checkValidity());
+  expect(invalid).toBe(false);
+});
+
+test('between pattern with custom format', async ({ page }) => {
+  const pattern = getPattern("Html5PatternGenerator\\\\Pattern\\\\DatePatternGenerator::between(new DateTimeImmutable('2024-05-01'), new DateTimeImmutable('2024-05-03'), 'd.m.Y')");
+
+  await page.setContent('<form><input id=\"date\"></form>');
+  await page.evaluate((p) => {
+    document.getElementById('date').setAttribute('pattern', p);
+  }, pattern);
+
+  const input = page.locator('#date');
+  await input.fill('02.05.2024');
+  const valid = await input.evaluate(el => el.checkValidity());
+  expect(valid).toBe(true);
+
+  await input.fill('04.05.2024');
+  const invalid = await input.evaluate(el => el.checkValidity());
+  expect(invalid).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add Playwright test using DatePatternGenerator
- include package.json and lockfile with Playwright dependency
- configure Playwright test directory
- document how to run browser tests
- update CI to run Playwright after PHPUnit
- ignore node modules and Playwright test results
- extend Playwright tests to cover more DatePatternGenerator methods

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`
- `npx playwright install --with-deps`
- `npm run test:browser`


------
https://chatgpt.com/codex/tasks/task_e_684b3b3360988320863ba5bd69b23fac