### PR TITLE
Enable static analysis and style checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
         with:
           php-version: '8.3'
       - run: composer install --no-interaction --prefer-dist
+      - run: vendor/bin/php-cs-fixer fix --dry-run --diff
+      - run: vendor/bin/phpstan analyse --no-progress
       - run: vendor/bin/phpunit --configuration phpunit.xml
       - uses: actions/setup-node@v3
         with:

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,10 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/src')
+    ->in(__DIR__.'/tests');
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+    ])
+    ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,8 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^10"
+        "phpunit/phpunit": "^10",
+        "phpstan/phpstan": "^2.1",
+        "friendsofphp/php-cs-fixer": "^3.75"
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,5 @@
+parameters:
+    level: max
+    paths:
+        - src
+        - tests

--- a/src/Pattern/DatePatternGenerator.php
+++ b/src/Pattern/DatePatternGenerator.php
@@ -4,7 +4,7 @@ namespace Html5PatternGenerator\Pattern;
 
 use DateInterval;
 use DatePeriod;
-use DateTimeInterface;
+use DateTimeImmutable;
 use InvalidArgumentException;
 
 class DatePatternGenerator
@@ -54,7 +54,7 @@ class DatePatternGenerator
     /**
      * Generate a regex pattern for all dates between two boundaries (inclusive).
      */
-    public static function between(DateTimeInterface $from, DateTimeInterface $to, string $format = 'Y-m-d'): string
+    public static function between(DateTimeImmutable $from, DateTimeImmutable $to, string $format = 'Y-m-d'): string
     {
         if ($to < $from) {
             throw new InvalidArgumentException('End date must not be earlier than start date');
@@ -72,7 +72,7 @@ class DatePatternGenerator
     /**
      * Generate a regex pattern for dates after the given date (inclusive) for a limited range.
      */
-    public static function after(DateTimeInterface $from, int $days = 365, string $format = 'Y-m-d'): string
+    public static function after(DateTimeImmutable $from, int $days = 365, string $format = 'Y-m-d'): string
     {
         $to = $from->modify('+' . $days . ' days');
         return self::between($from, $to, $format);
@@ -81,7 +81,7 @@ class DatePatternGenerator
     /**
      * Generate a regex pattern for dates before the given date (inclusive) for a limited range.
      */
-    public static function before(DateTimeInterface $to, int $days = 365, string $format = 'Y-m-d'): string
+    public static function before(DateTimeImmutable $to, int $days = 365, string $format = 'Y-m-d'): string
     {
         $from = $to->modify('-' . $days . ' days');
         return self::between($from, $to, $format);


### PR DESCRIPTION
## Summary
- require PHPStan and PHP CS Fixer
- configure coding style rules and static analysis
- update CI workflow to run PHPStan and PHP CS Fixer
- fix DatePatternGenerator types for PHPStan

## Testing
- `vendor/bin/php-cs-fixer fix --dry-run --diff`
- `vendor/bin/phpstan analyse --no-progress`
- `vendor/bin/phpunit --configuration phpunit.xml`
- `npm run test:browser`

------
https://chatgpt.com/codex/tasks/task_e_685804bc3ed08320b292e2dcd02a6dec