### PR TITLE
Enable strict types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ composer.lock
 node_modules/
 test-results/
 /.phpunit.result.cache
+
+.php-cs-fixer.cache

--- a/src/Pattern/DatePatternGenerator.php
+++ b/src/Pattern/DatePatternGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Html5PatternGenerator\Pattern;
 

--- a/src/Pattern/DatePatternGenerator.php
+++ b/src/Pattern/DatePatternGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Html5PatternGenerator\Pattern;

--- a/src/PatternGenerator.php
+++ b/src/PatternGenerator.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace Html5PatternGenerator;

--- a/src/PatternGenerator.php
+++ b/src/PatternGenerator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace Html5PatternGenerator;
 

--- a/tests/DatePatternGeneratorNegativeTest.php
+++ b/tests/DatePatternGeneratorNegativeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 use Html5PatternGenerator\Pattern\DatePatternGenerator;

--- a/tests/DatePatternGeneratorNegativeTest.php
+++ b/tests/DatePatternGeneratorNegativeTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Html5PatternGenerator\Pattern\DatePatternGenerator;
 use PHPUnit\Framework\TestCase;

--- a/tests/DatePatternGeneratorTest.php
+++ b/tests/DatePatternGeneratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 use Html5PatternGenerator\Pattern\DatePatternGenerator;

--- a/tests/DatePatternGeneratorTest.php
+++ b/tests/DatePatternGeneratorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Html5PatternGenerator\Pattern\DatePatternGenerator;
 use PHPUnit\Framework\TestCase;

--- a/tests/PatternGeneratorTest.php
+++ b/tests/PatternGeneratorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 use Html5PatternGenerator\PatternGenerator;

--- a/tests/PatternGeneratorTest.php
+++ b/tests/PatternGeneratorTest.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 use Html5PatternGenerator\PatternGenerator;
 use PHPUnit\Framework\TestCase;


### PR DESCRIPTION
## Summary
- enable strict types in source files
- enable strict types in tests

## Testing
- `composer install`
- `./vendor/bin/phpunit -c phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_6858076a21bc83208f72f109c7b30534