### PR TITLE
Declare PHP requirement and sync CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.3'
+          php-version: '8.2'
       - run: composer install --no-interaction --prefer-dist
       - run: vendor/bin/php-cs-fixer fix --dry-run --diff
       - run: vendor/bin/phpstan analyse --no-progress

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
             "Html5PatternGenerator\\": "src/"
         }
     },
+    "require": {
+        "php": "^8.2"
+    },
     "require-dev": {
         "phpunit/phpunit": "^10",
         "phpstan/phpstan": "^2.1",


### PR DESCRIPTION
## Summary
- specify minimum PHP version requirement
- use PHP 8.2 in CI

## Testing
- `composer install --no-interaction --prefer-dist`
- `vendor/bin/phpunit --configuration phpunit.xml`
- `vendor/bin/php-cs-fixer fix --dry-run --diff`
- `vendor/bin/phpstan analyse --no-progress`
- `npm install`
- `npx playwright install --with-deps`
- `npm run test:browser`


------
https://chatgpt.com/codex/tasks/task_e_68580a3ad48c8320a21dd0733e5d9f98