### PR TITLE
Clarify leap year validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ $datePattern = DatePatternGenerator::pattern();
 ```
 
 The pattern ensures only valid calendar dates are matched, so combinations like
-`2024-02-31` are rejected.
+`2024-02-31` are rejected. Leap years are **not** validated, meaning
+`2023-02-29` will still pass the regex. If you need to ensure a date exists,
+validate it with PHP's `checkdate()` or attempt to create a
+`DateTimeImmutable` instance after matching the pattern.
 
 Use a different format:
 

--- a/tests/DatePatternGeneratorTest.php
+++ b/tests/DatePatternGeneratorTest.php
@@ -64,8 +64,10 @@ class DatePatternGeneratorTest extends TestCase
     {
         $regex = '/^' . DatePatternGenerator::pattern() . '$/';
         $this->assertMatchesRegularExpression($regex, '2024-02-29');
-        // Pattern does not validate leap years, so 2023-02-29 also matches
+        // Pattern does not validate leap years, so 2023-02-29 also matches.
         $this->assertMatchesRegularExpression($regex, '2023-02-29');
+        // Recommended approach from README: use checkdate() for final validation
+        $this->assertFalse(checkdate(2, 29, 2023));
     }
 
     public function testUnknownFormatCharactersAreLiterals(): void


### PR DESCRIPTION
## Summary
- document that leap years aren't validated by DatePatternGenerator
- show how to use `checkdate()` for leap year checking
- update leap year test to demonstrate the recommended approach

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685819f00a7c8320990d57db00dca80a