### PR TITLE
Add composer scripts and development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,13 @@ npm install
 npx playwright install --with-deps
 npm run test:browser
 ```
+
+## Development
+
+Use Composer scripts to run checks during development:
+
+```bash
+composer test  # run unit tests
+composer cs    # check coding style
+composer stan  # run static analysis
+```

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,10 @@
         "phpunit/phpunit": "^10",
         "phpstan/phpstan": "^2.1",
         "friendsofphp/php-cs-fixer": "^3.75"
+    },
+    "scripts": {
+        "test": "phpunit",
+        "cs": "php-cs-fixer fix --dry-run --diff",
+        "stan": "phpstan analyse"
     }
 }


### PR DESCRIPTION
## Summary
- add composer scripts for `test`, `cs` and `stan`
- document composer scripts in README for development usage

## Testing
- `composer test`
- `composer cs`
- `composer stan`


------
https://chatgpt.com/codex/tasks/task_e_68581cb661fc8320924cbc6ca2a84383