### PR TITLE
Add time pattern generator

### DIFF
--- a/src/Pattern/TimePatternGenerator.php
+++ b/src/Pattern/TimePatternGenerator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Html5PatternGenerator\Pattern;
+
+class TimePatternGenerator
+{
+    /**
+     * Convert a PHP time format into a regex pattern.
+     */
+    public static function pattern(string $format = 'H:i'): string
+    {
+        $map = [
+            'H' => '(?:[01][0-9]|2[0-3])',
+            'i' => '[0-5][0-9]',
+            's' => '[0-5][0-9]',
+            ':' => ':',
+        ];
+
+        $regex = '';
+        $length = strlen($format);
+        for ($i = 0; $i < $length; $i++) {
+            $ch = $format[$i];
+            $regex .= $map[$ch] ?? preg_quote($ch, '/');
+        }
+
+        return $regex;
+    }
+}

--- a/tests/TimePatternGeneratorTest.php
+++ b/tests/TimePatternGeneratorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Html5PatternGenerator\Pattern\TimePatternGenerator;
+use PHPUnit\Framework\TestCase;
+
+class TimePatternGeneratorTest extends TestCase
+{
+    public function testMatchesValidTimes(): void
+    {
+        $regex = '/^' . TimePatternGenerator::pattern() . '$/';
+        $this->assertMatchesRegularExpression($regex, '00:00');
+        $this->assertMatchesRegularExpression($regex, '23:59');
+    }
+
+    public function testRejectsInvalidTimes(): void
+    {
+        $regex = '/^' . TimePatternGenerator::pattern() . '$/';
+        $this->assertDoesNotMatchRegularExpression($regex, '24:00');
+        $this->assertDoesNotMatchRegularExpression($regex, '12:60');
+        $this->assertDoesNotMatchRegularExpression($regex, '3:00');
+    }
+
+    public function testWithSeconds(): void
+    {
+        $regex = '/^' . TimePatternGenerator::pattern('H:i:s') . '$/';
+        $this->assertMatchesRegularExpression($regex, '12:30:15');
+        $this->assertDoesNotMatchRegularExpression($regex, '12:30');
+        $this->assertDoesNotMatchRegularExpression($regex, '12:30:60');
+    }
+}

--- a/tests/browser/timepattern.spec.js
+++ b/tests/browser/timepattern.spec.js
@@ -1,0 +1,48 @@
+const { test, expect } = require('@playwright/test');
+const { execSync } = require('child_process');
+const path = require('path');
+
+const root = path.resolve(__dirname, '../..');
+
+function getPattern(expr) {
+  const cmd = `php -r "require 'vendor/autoload.php'; echo ${expr};"`;
+  let pattern = execSync(cmd, { cwd: root }).toString();
+  pattern = pattern.trim().replace(/\\-/g, '-');
+  return pattern;
+}
+
+test('default pattern validates times', async ({ page }) => {
+  const pattern = getPattern('Html5PatternGenerator\\\\Pattern\\\\TimePatternGenerator::pattern()');
+
+  await page.setContent('<form><input id="time"></form>');
+  await page.evaluate((p) => {
+    document.getElementById('time').setAttribute('pattern', p);
+  }, pattern);
+
+  const input = page.locator('#time');
+  await input.fill('23:59');
+  const valid = await input.evaluate(el => el.checkValidity());
+  expect(valid).toBe(true);
+
+  await input.fill('24:00');
+  const invalid = await input.evaluate(el => el.checkValidity());
+  expect(invalid).toBe(false);
+});
+
+test('pattern with seconds validates times', async ({ page }) => {
+  const pattern = getPattern("Html5PatternGenerator\\\\Pattern\\\\TimePatternGenerator::pattern('H:i:s')");
+
+  await page.setContent('<form><input id="time"></form>');
+  await page.evaluate((p) => {
+    document.getElementById('time').setAttribute('pattern', p);
+  }, pattern);
+
+  const input = page.locator('#time');
+  await input.fill('12:30:15');
+  const valid = await input.evaluate(el => el.checkValidity());
+  expect(valid).toBe(true);
+
+  await input.fill('12:30:60');
+  const invalid = await input.evaluate(el => el.checkValidity());
+  expect(invalid).toBe(false);
+});


### PR DESCRIPTION
## Summary
- implement `TimePatternGenerator` to build HH:MM(:SS) patterns
- test time patterns with PHPUnit
- add browser tests for time patterns

## Testing
- `vendor/bin/phpunit --testdox`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68581d0f7aac83209064dfb43f44adb8