### PR TITLE
Add PHP version matrix to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: ['8.2', '8.3']
     steps:
       - uses: actions/checkout@v3
       - uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.2'
+          php-version: ${{ matrix.php-version }}
       - run: composer install --no-interaction --prefer-dist
       - run: vendor/bin/php-cs-fixer fix --dry-run --diff
       - run: vendor/bin/phpstan analyse --no-progress


### PR DESCRIPTION
## Summary
- run PHP 8.2 and 8.3 in CI job matrix

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`
- `vendor/bin/phpstan analyse --no-progress`
- `vendor/bin/php-cs-fixer fix --dry-run --diff`
- `npm run test:browser`


------
https://chatgpt.com/codex/tasks/task_e_68581fdc2be48320a6102a002973838c