### PR TITLE
Add .gitattributes to exclude dev files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Exclude development resources from distribution archives
+/tests export-ignore
+/.github export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/phpstan.neon.dist export-ignore
+/phpunit.xml export-ignore
+/playwright.config.js export-ignore
+/package.json export-ignore
+/package-lock.json export-ignore
+/.gitignore export-ignore


### PR DESCRIPTION
## Summary
- add `.gitattributes` to exclude dev resources from archives
- verify archive contents show only production files

## Testing
- `git archive --format=tar HEAD | tar -tv | sort`

------
https://chatgpt.com/codex/tasks/task_e_685821256b90832086c76d0ee5a58bb9