### PR TITLE
Add caching to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,13 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: composer-${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            composer-${{ runner.os }}-
       - run: composer install --no-interaction --prefer-dist
       - run: vendor/bin/php-cs-fixer fix --dry-run --diff
       - run: vendor/bin/phpstan analyse --no-progress
@@ -22,6 +29,13 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
+      - name: Cache npm dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-
       - run: npm install
       - run: npx playwright install --with-deps
       - run: npm run test:browser


### PR DESCRIPTION
## Summary
- cache Composer vendor dir based on `composer.lock`
- cache npm dependencies based on `package-lock.json`

## Testing
- `vendor/bin/php-cs-fixer fix --dry-run --diff`
- `vendor/bin/phpstan analyse --no-progress`
- `vendor/bin/phpunit --configuration phpunit.xml`
- `npm run test:browser`
- `composer install --no-interaction --prefer-dist`
- `npm install`
- `npx playwright install --with-deps`

------
https://chatgpt.com/codex/tasks/task_e_685821336a848320a7faa4ba89103f51