### PR TITLE
Add PHPUnit coverage to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          coverage: xdebug
       - name: Cache Composer dependencies
         uses: actions/cache@v3
         with:
@@ -25,7 +26,14 @@ jobs:
       - run: composer install --no-interaction --prefer-dist
       - run: vendor/bin/php-cs-fixer fix --dry-run --diff
       - run: vendor/bin/phpstan analyse --no-progress
-      - run: vendor/bin/phpunit --configuration phpunit.xml
+      - run: mkdir -p build
+      - run: vendor/bin/phpunit --coverage-text --coverage-clover build/coverage.xml
+        env:
+          XDEBUG_MODE: coverage
+      - uses: actions/upload-artifact@v3
+        with:
+          name: php-coverage-${{ matrix.php-version }}
+          path: build/coverage.xml
       - uses: actions/setup-node@v3
         with:
           node-version: '20'

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ composer.lock
 /vendor/
 node_modules/
 test-results/
+build/
 /.phpunit.result.cache
 
 .php-cs-fixer.cache


### PR DESCRIPTION
## Summary
- enable Xdebug in CI via setup-php
- run PHPUnit with coverage options and upload the result
- ignore build folder in git

## Testing
- `vendor/bin/phpunit --configuration phpunit.xml`
- `npm run test:browser`


------
https://chatgpt.com/codex/tasks/task_e_685822f1ad908320ad51822bc01b9b33