### PR TITLE
Add negative tests for numericRange

### DIFF
--- a/tests/PatternGeneratorNegativeTest.php
+++ b/tests/PatternGeneratorNegativeTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Html5PatternGenerator\PatternGenerator;
+use PHPUnit\Framework\TestCase;
+
+class PatternGeneratorNegativeTest extends TestCase
+{
+    public function testNumericRangeThrowsForMinGreaterThanMax(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        PatternGenerator::numericRange(5, 3);
+    }
+
+    public function testNumericRangeThrowsForNegativeBound(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        PatternGenerator::numericRange(-1, 3);
+    }
+}


### PR DESCRIPTION
## Summary
- add PatternGeneratorNegativeTest verifying InvalidArgumentException for bad numericRange arguments

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685822f72724832095be81e9755aa2ae