### PR TITLE
Add WeekPatternGenerator with week regex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ $futurePattern = DatePatternGenerator::after(new DateTimeImmutable('2024-06-01')
 $pastPattern = DatePatternGenerator::before(new DateTimeImmutable('2024-06-01'), 7);
 ```
 
+### Week pattern
+
+Generate a regex for `YYYY-Www` formatted ISO weeks:
+
+```php
+use Html5PatternGenerator\Pattern\WeekPatternGenerator;
+
+$weekPattern = WeekPatternGenerator::pattern();
+```
+
+
 ### Configurable patterns
 
 `PatternGenerator` can build simple character class based expressions. Options

--- a/src/Pattern/WeekPatternGenerator.php
+++ b/src/Pattern/WeekPatternGenerator.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Html5PatternGenerator\Pattern;
+
+class WeekPatternGenerator
+{
+    /**
+     * Convert a PHP week format into a regex pattern.
+     */
+    public static function pattern(string $format = 'Y-\\WW'): string
+    {
+        $map = [
+            'Y' => '\\d{4}',
+            'W' => '(?:0[1-9]|[1-4][0-9]|5[0-3])',
+        ];
+
+        $regex = '';
+        $length = strlen($format);
+        for ($i = 0; $i < $length; $i++) {
+            $ch = $format[$i];
+            if ($ch === '\\') {
+                $i++;
+                if ($i < $length) {
+                    $regex .= preg_quote($format[$i], '/');
+                }
+                continue;
+            }
+            $regex .= $map[$ch] ?? preg_quote($ch, '/');
+        }
+
+        return $regex;
+    }
+}

--- a/tests/WeekPatternGeneratorTest.php
+++ b/tests/WeekPatternGeneratorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Html5PatternGenerator\Pattern\WeekPatternGenerator;
+use PHPUnit\Framework\TestCase;
+
+class WeekPatternGeneratorTest extends TestCase
+{
+    public function testMatchesValidWeeks(): void
+    {
+        $regex = '/^' . WeekPatternGenerator::pattern() . '$/';
+        $this->assertMatchesRegularExpression($regex, '2024-W01');
+        $this->assertMatchesRegularExpression($regex, '2024-W53');
+    }
+
+    public function testRejectsInvalidWeeks(): void
+    {
+        $regex = '/^' . WeekPatternGenerator::pattern() . '$/';
+        $this->assertDoesNotMatchRegularExpression($regex, '2024-W00');
+        $this->assertDoesNotMatchRegularExpression($regex, '2024-W54');
+        $this->assertDoesNotMatchRegularExpression($regex, '2024-W1');
+    }
+}


### PR DESCRIPTION
## Summary
- implement `WeekPatternGenerator` for ISO week formats
- test week regex generation
- document week pattern usage in README

## Testing
- `composer cs`
- `composer stan`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_685826bb708c83209a16b57d3ad8241e