### PR TITLE
Add MonthPatternGenerator

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,22 @@ $futurePattern = DatePatternGenerator::after(new DateTimeImmutable('2024-06-01')
 $pastPattern = DatePatternGenerator::before(new DateTimeImmutable('2024-06-01'), 7);
 ```
 
+### Month pattern
+
+Generate a regex for `YYYY-MM` formatted months:
+
+```php
+use Html5PatternGenerator\Pattern\MonthPatternGenerator;
+
+$monthPattern = MonthPatternGenerator::pattern();
+```
+
+The pattern matches months from `0000-01` up to `9999-12`. Use a different format if needed:
+
+```php
+$altMonth = MonthPatternGenerator::pattern('m/Y');
+```
+
 ### Configurable patterns
 
 `PatternGenerator` can build simple character class based expressions. Options

--- a/src/Pattern/MonthPatternGenerator.php
+++ b/src/Pattern/MonthPatternGenerator.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Html5PatternGenerator\Pattern;
+
+class MonthPatternGenerator
+{
+    /**
+     * Convert a PHP month format into a regex pattern.
+     */
+    public static function pattern(string $format = 'Y-m'): string
+    {
+        $map = [
+            'Y' => '\\d{4}',
+            'm' => '(?:0[1-9]|1[0-2])',
+            '-' => '-',
+        ];
+
+        $regex = '';
+        $length = strlen($format);
+        for ($i = 0; $i < $length; $i++) {
+            $ch = $format[$i];
+            $regex .= $map[$ch] ?? preg_quote($ch, '/');
+        }
+
+        return $regex;
+    }
+}

--- a/tests/MonthPatternGeneratorTest.php
+++ b/tests/MonthPatternGeneratorTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Html5PatternGenerator\Pattern\MonthPatternGenerator;
+use PHPUnit\Framework\TestCase;
+
+class MonthPatternGeneratorTest extends TestCase
+{
+    public function testMatchesValidMonths(): void
+    {
+        $regex = '/^' . MonthPatternGenerator::pattern() . '$/';
+        $this->assertMatchesRegularExpression($regex, '2024-01');
+        $this->assertMatchesRegularExpression($regex, '1999-12');
+    }
+
+    public function testRejectsInvalidMonths(): void
+    {
+        $regex = '/^' . MonthPatternGenerator::pattern() . '$/';
+        $this->assertDoesNotMatchRegularExpression($regex, '2024-13');
+        $this->assertDoesNotMatchRegularExpression($regex, '2024-00');
+        $this->assertDoesNotMatchRegularExpression($regex, '2024-1');
+    }
+
+    public function testDifferentFormat(): void
+    {
+        $regex = '/^' . MonthPatternGenerator::pattern('m/Y') . '$/';
+        $this->assertMatchesRegularExpression($regex, '05/2024');
+        $this->assertDoesNotMatchRegularExpression($regex, '2024-05');
+    }
+}

--- a/tests/browser/monthpattern.spec.js
+++ b/tests/browser/monthpattern.spec.js
@@ -1,0 +1,48 @@
+const { test, expect } = require('@playwright/test');
+const { execSync } = require('child_process');
+const path = require('path');
+
+const root = path.resolve(__dirname, '../..');
+
+function getPattern(expr) {
+  const cmd = `php -r "require 'vendor/autoload.php'; echo ${expr};"`;
+  let pattern = execSync(cmd, { cwd: root }).toString();
+  pattern = pattern.trim().replace(/\\-/g, '-');
+  return pattern;
+}
+
+test('default pattern validates months', async ({ page }) => {
+  const pattern = getPattern('Html5PatternGenerator\\\\Pattern\\\\MonthPatternGenerator::pattern()');
+
+  await page.setContent('<form><input id="month"></form>');
+  await page.evaluate((p) => {
+    document.getElementById('month').setAttribute('pattern', p);
+  }, pattern);
+
+  const input = page.locator('#month');
+  await input.fill('2024-05');
+  const valid = await input.evaluate(el => el.checkValidity());
+  expect(valid).toBe(true);
+
+  await input.fill('2024-13');
+  const invalid = await input.evaluate(el => el.checkValidity());
+  expect(invalid).toBe(false);
+});
+
+test('custom format m/Y validates months', async ({ page }) => {
+  const pattern = getPattern("Html5PatternGenerator\\\\Pattern\\\\MonthPatternGenerator::pattern('m/Y')");
+
+  await page.setContent('<form><input id="month"></form>');
+  await page.evaluate((p) => {
+    document.getElementById('month').setAttribute('pattern', p);
+  }, pattern);
+
+  const input = page.locator('#month');
+  await input.fill('05/2024');
+  const valid = await input.evaluate(el => el.checkValidity());
+  expect(valid).toBe(true);
+
+  await input.fill('2024-05');
+  const invalid = await input.evaluate(el => el.checkValidity());
+  expect(invalid).toBe(false);
+});


### PR DESCRIPTION
## Summary
- add `MonthPatternGenerator`
- cover with PHP unit tests
- add Playwright browser tests
- document month pattern usage in README

## Testing
- `composer test`
- `composer cs`
- `composer stan`
- `npm run test:browser`


------
https://chatgpt.com/codex/tasks/task_e_685826b848f083209399c13ee735ed17